### PR TITLE
Replace django-fsm with django-fsm-2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all:
 	@echo
 
 version:
-	@echo "fsm_admim.__version__ == $(VERSION)"
+	@echo "fsm_admin.__version__ == $(VERSION)"
 
 help:
 	@echo " Make targets"

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 django-fsm-admin
 ================
 
-Mixin and template tags to integrate django-fsm_ state transitions into the
+Mixin and template tags to integrate django-fsm-2_ state transitions into the
 Django Admin.
 
 Installation
@@ -102,4 +102,4 @@ Try the example
    $ python manage.py runserver
 
 
-.. _django-fsm: https://github.com/kmmbvnr/django-fsm
+.. _django-fsm-2: https://github.com/pfouque/django-fsm-2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Django>=1.6
-django-fsm==2.0.1
+django-fsm-2>=3.0.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "Django>=1.6",
-        "django-fsm>=2.1.0",
+        "django-fsm-2>=3.0.0",
     ],
     keywords="django fsm admin",
     license="MIT",


### PR DESCRIPTION
django-fsm has been deprecated https://github.com/viewflow/django-fsm
A fork has been created to replace it https://github.com/pfouque/django-fsm-2

This PR drops the django-fsm dependency and replaces it with django-fsm-2